### PR TITLE
Replace jsonpath with jsonpath-plus

### DIFF
--- a/lib/Input-value-cache.js
+++ b/lib/Input-value-cache.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const jp = require('jsonpath')
+const {JSONPath} = require('jsonpath-plus');
 
 class InputValueCache {
   constructor () {
@@ -14,7 +14,7 @@ class InputValueCache {
       return this.cache[inputPath]
     }
 
-    let value = jp.query(values, inputPath)
+    let value = JSONPath({path: inputPath, json: values, wrap: false})
 
     if (Array.isArray(value)) {
       const l = value.length

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "jsonpath": "1.1.1",
+    "jsonpath-plus": "10.3.0",
     "lodash": "4.17.21"
   },
   "devDependencies": {


### PR DESCRIPTION
I was trying to use the `asl-choice-processor` in my own state machine library, and when building I was running into issues with the `jsonpath` dependency, specifically because it is using `require.resolve` in a couple of places:

https://github.com/search?q=repo%3Adchester%2Fjsonpath%20require.resolve&type=code

This PR replaces `jsonpath` with `jsonpath-plus`, which is bundled for newer versions of node and also browsers. jsonpath-plus is not a drop in replacement so I had to update `jp.query(values, inputPath)` with `JSONPath({path: inputPath, json: values, wrap: false})`. 

Tests pass after changes. 

Thank you for creating and maintaining this library!